### PR TITLE
2.13 prep: Unicode escapes in triple quoted strings are deprecated, u…

### DIFF
--- a/src/test/scala/fm/json/TestJson.scala
+++ b/src/test/scala/fm/json/TestJson.scala
@@ -77,7 +77,7 @@ final class TestJson extends FunSuite with Matchers with AppendedClues {
       |    "two",
       |    3.3
       |  ],
-      |  "unicode" : "Hello \r\t\n \\ \/ \" \b\f oneByte: \u0024 twoByte: \u00A2 threeByte: \u20AC fourByteSupplementary: \uD83D\uDCA5  World!"
+      |  "unicode" : "Hello \r\t\n \\ \/ \" \b\f""".stripMargin.trim + " oneByte: \u0024 twoByte: \u00A2 threeByte: \u20AC fourByteSupplementary: \uD83D\uDCA5  " + """World!"
       |}
       |""".stripMargin.trim
 
@@ -174,7 +174,7 @@ final class TestJson extends FunSuite with Matchers with AppendedClues {
       |    "two",
       |    3.3
       |  ],
-      |  "unicode" : "Hello \r\t\n \\ \/ \" \b\f oneByte: \u0024 twoByte: \u00A2 threeByte: \u20AC fourByteSupplementary: \uD83D\uDCA5  World!"
+      |  "unicode" : "Hello \r\t\n \\ \/ \" \b\f""".stripMargin.trim + " oneByte: \u0024 twoByte: \u00A2 threeByte: \u20AC fourByteSupplementary: \uD83D\uDCA5  " + """World!"
       |}
       |""".stripMargin.trim
 


### PR DESCRIPTION
…se the literal character instead

With `2.13.2`:

```
$ sbt +test
[info] Run completed in 248 milliseconds.
[info] Total number of tests run: 20
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 20, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 2 s, completed May 13, 2020, 4:05:42 PM
```